### PR TITLE
[Feature] Workflow to build and push Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-image-update.yml
+++ b/.github/workflows/docker-image-update.yml
@@ -1,0 +1,31 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    paths:
+      - ".devcontainer/Dockerfile"
+      - ".github/workflows/docker-image-update.yml"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/elf-ripper/elf-ripper-dev-test-env:latest -f .devcontainer/Dockerfile .
+
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/elf-ripper/elf-ripper-dev-test-env:latest


### PR DESCRIPTION
- Image named `elf-ripper-dev-test-env` for development and testing environment
- Triggers on changes to Dockerfile and workflow file, with manual trigger option